### PR TITLE
card number now visible in your payment methods

### DIFF
--- a/pages/payments.js
+++ b/pages/payments.js
@@ -43,7 +43,7 @@ export default function Payments() {
             payments.map(payment => (
               <tr key={payment.id}>
                 <td>{payment.merchant_name}</td>
-                <td>{payment.obscured_num}</td>
+                <td>{payment.account_number}</td>
                 <td>
                   <span className="icon is-clickable" onClick={() => removePayment(payment.id)}>
                     <i className="fas fa-trash"></i>


### PR DESCRIPTION
Changed the payment object to display the account number of the payment object. 